### PR TITLE
New useRawSerial feature to fix #3 and #4

### DIFF
--- a/midi.ts
+++ b/midi.ts
@@ -72,8 +72,20 @@ namespace midi {
         transport(buf);
     }
 
+     /**
+     * Send raw MIDI messages via serial
+     */
+    //% blockId=midi_raw_serial_transport block="midi use raw serial"
+    //% advanced=true
+    export function useRawSerial() {
+        function send(data: Buffer): void {
+            serial.writeBuffer(data)
+        }
+        setTransport(send)
+    }
+    
     /**
-     * Send MIDI messages via serial
+     * Send human readable MIDI messages via serial
      */
     //% blockId=midi_serial_transport block="midi use serial"
     //% advanced=true


### PR DESCRIPTION
This feature allows the transmission of RAW (unintelligible to most humans) MIDI data over Serial. This is for direct compatibility with off-the-shell MIDI <-> Serial bridge applications such as Hairless MIDI.

Simply add the block "useRawSerial" into "on start" instead of "useSerial".

It's possible to write a Python client to parse the output of "useSerial" and inject it directly into the MIDI subsystem on Linux at least, but since Hairless MIDI is cross-platform and free it seems sensible to support it directly.