### PR TITLE
Number bounds clamping fix for #1

### DIFF
--- a/midi.ts
+++ b/midi.ts
@@ -163,7 +163,7 @@ namespace midi {
         //% blockGap=8 weight=81
         //% subcategory="Channels"
         noteOn(key: number, velocity = 0): void {
-            if (key < 0 || key > 0x7F) return;
+            if (key < 0 || key > 0x7f) return;
 
             sendMessage([0x90 | this.channel, key, velocity || this.velocity]);
         }
@@ -177,7 +177,7 @@ namespace midi {
         //% blockGap=8 weight=80
         //% subcategory="Channels"
         noteOff(key: number, velocity = 0): void {
-            if (key < 0 || key > 0x7F) return;
+            if (key < 0 || key > 0x7f) return;
 
             sendMessage([0x80 | this.channel, key, velocity || this.velocity]);
         }
@@ -206,7 +206,7 @@ namespace midi {
         //% blockGap=8 weight=79
         //% subcategory="Channels"
         setVelocity(velocity: number): void {
-            this.velocity = velocity & 0x7F;
+            this.velocity = velocity & 0x7f;
         }
 
         /**
@@ -241,7 +241,7 @@ namespace midi {
         //% subcategory="Channels"
         //% program.min=0 program.max=127
         programChange(program: number) {
-            sendMessage([0xc0 | this.channel, program & 0xf]);
+            sendMessage([0xc0 | this.channel, program & 0x7f]);
         }
 
         /**
@@ -254,7 +254,7 @@ namespace midi {
         //% subcategory="Channels"
         //% pressure.min=0 pressure.max=127
         aftertouch(pressure: number) {
-            sendMessage([0xd0 | this.channel, pressure & 0xf]);
+            sendMessage([0xd0 | this.channel, pressure & 0x7f]);
         }
 
         /**
@@ -268,7 +268,7 @@ namespace midi {
         //% key.min=0 key.max=127
         //% pressure.min=0 pressure.max=127
         polyphonicAftertouch(key: number, pressure: number) {
-            sendMessage([0xa0 | this.channel, key & 0xf, pressure & 0xf]);
+            sendMessage([0xa0 | this.channel, key & 0x7f, pressure & 0x7f]);
         }
 
         /**
@@ -283,7 +283,7 @@ namespace midi {
         //% fn.min=0 fn.max=119
         //% value.min=0 value.max=127
         controlChange(fn: number, value: number) {
-            sendMessage([0xb0 | this.channel, fn & 0xf, value & 0xf]);
+            sendMessage([0xb0 | this.channel, fn & 0x7f, value & 0x7f]);
         }
 
         /**
@@ -294,7 +294,7 @@ namespace midi {
         //% blockGap=8
         //% subcategory="Channels"
         channelMode(mode: MidiChannelMode) {
-            sendMessage([0xb0 | this.channel, (mode >> 8) & 0xf, mode & 0xf]);
+            sendMessage([0xb0 | this.channel, (mode >> 8) & 0x7f, mode & 0x7f]);
         }
     }
 


### PR DESCRIPTION
This fix changes various changes from 4-bit values, to clamp at the 7-bit values documented here: https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message

Actual values may vary, as noted by the 0-119 range already existing on the control value in `controlChange`.